### PR TITLE
feat: enable GA4 with gtag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -155,9 +155,10 @@ social:
 
 # Analytics
 analytics:
-  provider               :  "false" # false (default), "google", "google-universal", "google-analytics-4", "custom"
+  provider               : "google-gtag" # false (default), "google", "google-universal", "google-analytics-4", "custom"
   google:
-    tracking_id          :
+    tracking_id          : "G-2NNHP09N59"
+    anonymize_ip         : true
 
 
 # Reading Files


### PR DESCRIPTION
This pull request updates the analytics configuration in the `_config.yml` file to enable Google Analytics tracking using the `google-gtag` provider.

Key changes to analytics configuration:

* Updated the `provider` field under `analytics` to use `google-gtag` instead of the default `false`.
* Added a `tracking_id` with the value `G-2NNHP09N59` for Google Analytics tracking.
* Introduced the `anonymize_ip` setting and set it to `true` to enable IP anonymization.