### PR TITLE
feat: remove analytics include from author profile

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,7 +1,5 @@
 {% include base_path %}
 
-{% include analytics.html %}
-
 {% if page.author and site.data.authors[page.author] %}
   {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.author %}
 {% endif %}


### PR DESCRIPTION
This pull request makes a small change to the `_includes/author-profile.html` file by removing the inclusion of the `analytics.html` file, simplifying the template.